### PR TITLE
build(client): generate a UMD bundle

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,10 +16,10 @@
   "main": "build/index.js",
   "module": "build/index.es.js",
   "types": "build/types/index.d.ts",
-  "browser": "build/webcrypto-socket.mjs",
-  "browser:min": "build/webcrypto-socket.min.mjs",
-  "browser:es5": "build/webcrypto-socket.js",
-  "browser:es5:min": "build/webcrypto-socket.min.js",
+  "browser": "build/webcrypto-socket.js",
+  "browser:min": "build/webcrypto-socket.min.js",
+  "browser:es5": "build/webcrypto-socket.es5.js",
+  "browser:es5:min": "build/webcrypto-socket.es5.min.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/client/rollup.config.js
+++ b/packages/client/rollup.config.js
@@ -114,17 +114,15 @@ const browser = [
     output: [
       {
         banner,
-        footer: "self.WebcryptoSocket=WebcryptoSocket;",
         file: pkg["browser"],
-        format: "iife",
+        format: "umd",
         name: "WebcryptoSocket",
         globals: browserExternals,
       },
       {
         banner,
-        footer: "self.WebcryptoSocket=WebcryptoSocket;",
         file: pkg["browser:min"],
-        format: "iife",
+        format: "umd",
         name: "WebcryptoSocket",
         globals: browserExternals,
         plugins: [
@@ -144,14 +142,14 @@ const browser = [
       {
         banner,
         file: pkg["browser:es5"],
-        format: "iife",
+        format: "umd",
         name: "WebcryptoSocket",
         globals: browserExternals,
       },
       {
         banner,
         file: pkg["browser:es5:min"],
-        format: "iife",
+        format: "umd",
         name: "WebcryptoSocket",
         globals: browserExternals,
         plugins: [


### PR DESCRIPTION
First commit

```
build(client): generate a UMD bundle
    
A UMD bundle can be used as a regular CommonJS module by bundlers and
included in other bundles.
```

Second commit

```
build(client): drop the .mjs extension
    
The .mjs extension is misleading as the generated bundle is not an
ECMAScript module and prevents bundlers from working properly.
```