### PR TITLE
Fix GitHub script for commenting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,11 +85,11 @@ jobs:
         uses: actions/github-script@v7
         if: env.PREV_VERSION != env.CURRENT_VERSION
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'NPM package v${{ env.CURRENT_VERSION }} has been published 🎉'
+              body: 'NPM package v${{env.CURRENT_VERSION}} has been published 🎉'
             })


### PR DESCRIPTION
This pull request fixes the GitHub script for commenting by updating the `github.rest.issues.createComment` in the workflow file. The previous version had a syntax error, and this PR corrects it.