### PR TITLE
PCSC Service Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "pub:next": "lerna publish --dist-tag next",
     "lint": "tslint -p .",
     "lint:fix": "tslint --fix -p .",
-    "start": "ts-node scripts/server.ts",
+    "start": "ts-node -r tsconfig-paths/register scripts/server.ts",
     "docs": "typedoc && touch ./docs/.nojekyll",
     "docs:deploy": "gh-pages -d docs -t",
     "upgrade": "yarn upgrade-interactive --latest",
@@ -90,7 +90,7 @@
     "tar": "^6.1.11",
     "trim-off-newlines": "^1.0.3",
     "shelljs": "^0.8.5",
-    "pkcs11js": "^2.1.4",
+    "pkcs11js": "2.1.6",
     "@peculiar/asn1-schema": "^2.1.7",
     "tsprotobuf": "^1.0.19"
   },

--- a/packages/cards/package.json
+++ b/packages/cards/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "@peculiar/json-schema": "^1.1.12",
-    "tslib": "^2.6.3"
+    "tslib": "^2.7.0"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -48,7 +48,7 @@
     "@webcrypto-local/proto": "^1.9.0",
     "idb": "^2",
     "pvtsutils": "^1.3.5",
-    "tslib": "^2.6.3",
+    "tslib": "^2.7.0",
     "webcrypto-core": "^1.8.0",
     "ws": "^8.17.0"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,6 @@
   "dependencies": {
     "2key-ratchet": "^1.0.18",
     "pvtsutils": "^1.3.5",
-    "tslib": "^2.6.3"
+    "tslib": "^2.7.0"
   }
 }

--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -39,8 +39,8 @@
   },
   "dependencies": {
     "@webcrypto-local/core": "^1.9.0",
-    "pvtsutils": "^1.3.2",
-    "tslib": "^2.4.0",
-    "tsprotobuf": "^1.0.18"
+    "pvtsutils": "^1.3.5",
+    "tslib": "^2.7.0",
+    "tsprotobuf": "^1.0.19"
   }
 }

--- a/packages/server/DEVELOPERS.md
+++ b/packages/server/DEVELOPERS.md
@@ -1,0 +1,43 @@
+# Developers Guide
+
+Welcome to the Developers Guide for this project. This document provides essential information and instructions for developers working on the project. It includes guidelines for setting up the development environment, managing dependencies, running tests, and other important tasks.
+
+## Managing PCSC Service on Windows
+
+For testing various states of the PCSC (Smart Card) service on Windows, you may need to start, stop, and change the startup type of the service. Below are the commands to manage the PCSC service.
+
+**Note:** Ensure you open the terminal with administrative privileges to execute these commands.
+
+### Disable and Stop the PCSC Service
+
+To disable and stop the PCSC service, run the following commands in PowerShell with administrative privileges:
+
+```powershell
+# Disable the PCSC service
+Set-Service -Name "SCardSvr" -StartupType Disabled
+
+# Stop the PCSC service
+Stop-Service -Name "SCardSvr"
+```
+
+### Enable and Start the PCSC Service
+
+To enable and start the PCSC service, run the following commands in PowerShell with administrative privileges:
+
+```powershell
+# Set the PCSC service to start automatically
+Set-Service -Name "SCardSvr" -StartupType Automatic
+
+# Start the PCSC service
+Start-Service -Name "SCardSvr"
+```
+
+### Check the Status of the PCSC Service
+
+To check the current status of the PCSC service, run the following command in PowerShell:
+
+```powershell
+Get-Service -Name "SCardSvr"
+```
+
+This command will display the current status of the service, including whether it is running, stopped, and its startup type.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -39,26 +39,26 @@
   },
   "dependencies": {
     "2key-ratchet": "^1.0.18",
-    "@peculiar/asn1-ocsp": "^2.3.8",
-    "@peculiar/asn1-schema": "^2.3.8",
-    "@peculiar/asn1-x509": "^2.3.8",
+    "@peculiar/asn1-ocsp": "^2.3.13",
+    "@peculiar/asn1-schema": "^2.3.13",
+    "@peculiar/asn1-x509": "^2.3.13",
     "@peculiar/json-schema": "^1.1.12",
     "@peculiar/webcrypto": "1.0.22",
-    "@peculiar/x509": "^1.11.0",
+    "@peculiar/x509": "^1.12.1",
     "@types/pvutils": "^1.0.4",
     "@webcrypto-local/cards": "^1.10.2",
     "@webcrypto-local/core": "^1.9.0",
     "@webcrypto-local/proto": "^1.9.0",
-    "graphene-pk11": "^2.3.5",
-    "node-webcrypto-p11": "^2.6.4",
+    "graphene-pk11": "^2.3.6",
+    "node-webcrypto-p11": "^2.6.5",
     "pcsclite": "^1.0.1",
     "pvtsutils": "^1.3.5",
     "pvutils": "^1.1.3",
-    "tslib": "^2.6.3",
+    "tslib": "^2.7.0",
     "webcrypto-core": "^1.8.0",
     "ws": "^8.17.0"
   },
   "resolutions": {
-    "pkcs11js": "^2.1.4"
+    "pkcs11js": "^2.1.6"
   }
 }

--- a/scripts/server.ts
+++ b/scripts/server.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { setEngine } from "2key-ratchet";
 import * as fs from "fs";
 import * as os from "os";
@@ -10,7 +11,7 @@ async function main() {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
   // Set crypto engine for 2key-ratchet
-  setEngine("WebCrypto NodeJS", crypto);
+  setEngine("WebCrypto NodeJS", crypto.webcrypto as Crypto);
 
   const platform = os.platform();
   const FORTIFY_DATA_DIR = path.join(os.homedir(), ".fortify");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1622,13 +1622,13 @@
     asn1js "^3.0.5"
     tslib "^2.6.2"
 
-"@peculiar/asn1-ocsp@^2.3.8":
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-ocsp/-/asn1-ocsp-2.3.8.tgz#53b4905aa7510da332e8aa8e8387a9dee8fe10d5"
-  integrity sha512-nbUQwR86DrM4c+MQkoIAVcyrYajZtpdeArTC/ioMKaPkXpcEvlURL+gZ3pERXO7hBoeAHODLshH8YvmWxkoQMw==
+"@peculiar/asn1-ocsp@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-ocsp/-/asn1-ocsp-2.3.13.tgz#4d44cc28ec1636c699a5e4d8a0d0293e6c9da74a"
+  integrity sha512-P5tcRT0IBZih4obeWdoAUCsyIomG6WXBZjj98282JMM/5VBs0GQWxg1H1HGg9/vHz/CQGjOMfHfVLplWgoi+sg==
   dependencies:
-    "@peculiar/asn1-schema" "^2.3.8"
-    "@peculiar/asn1-x509" "^2.3.8"
+    "@peculiar/asn1-schema" "^2.3.13"
+    "@peculiar/asn1-x509" "^2.3.13"
     asn1js "^3.0.5"
     tslib "^2.6.2"
 
@@ -1678,7 +1678,7 @@
     asn1js "^3.0.5"
     tslib "^2.6.2"
 
-"@peculiar/asn1-schema@^1.0.3", "@peculiar/asn1-schema@^2.1.7", "@peculiar/asn1-schema@^2.3.8":
+"@peculiar/asn1-schema@^1.0.3", "@peculiar/asn1-schema@^2.1.7", "@peculiar/asn1-schema@^2.3.13", "@peculiar/asn1-schema@^2.3.8":
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz#3dd3c2ade7f702a9a94dfb395c192f5fa5d6b922"
   integrity sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==
@@ -1695,6 +1695,17 @@
     "@peculiar/asn1-schema" "^2.3.8"
     "@peculiar/asn1-x509" "^2.3.8"
     asn1js "^3.0.5"
+    tslib "^2.6.2"
+
+"@peculiar/asn1-x509@^2.3.13":
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509/-/asn1-x509-2.3.13.tgz#3616fb879b61f1f161a61660ca92f6fe4107af7a"
+  integrity sha512-PfeLQl2skXmxX2/AFFCVaWU8U6FKW1Db43mgBhShCOFS1bVxqtvusq1hVjfuEcuSQGedrLdCSvTgabluwN/M9A==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.3.13"
+    asn1js "^3.0.5"
+    ipaddr.js "^2.1.0"
+    pvtsutils "^1.3.5"
     tslib "^2.6.2"
 
 "@peculiar/asn1-x509@^2.3.8":
@@ -1727,10 +1738,10 @@
     tslib "^1.10.0"
     webcrypto-core "^1.0.17"
 
-"@peculiar/x509@^1.11.0", "@peculiar/x509@^1.9.6":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@peculiar/x509/-/x509-1.11.0.tgz#a60d2576c6496ef9839c0de148e4c75c905a127d"
-  integrity sha512-8rdxE//tsWLb2Yo2TYO2P8gieStbrHK/huFMV5PPfwX8I5HmtOus+Ox6nTKrPA9o+WOPaa5xKenee+QdmHBd5g==
+"@peculiar/x509@^1.12.1":
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/@peculiar/x509/-/x509-1.12.1.tgz#f879a918862f1c058524dca1ddbf259fc6aa6694"
+  integrity sha512-2T9t2viNP9m20mky50igPTpn2ByhHl5NlT6wW4Tp4BejQaQ5XDNZgfsabYwYysLXhChABlgtTCpp2gM3JBZRKA==
   dependencies:
     "@peculiar/asn1-cms" "^2.3.8"
     "@peculiar/asn1-csr" "^2.3.8"
@@ -4011,13 +4022,13 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
-graphene-pk11@^2.3.4, graphene-pk11@^2.3.5:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/graphene-pk11/-/graphene-pk11-2.3.5.tgz#3d90703baa0877dd941dd5e9e9b67a62bd5e9f8f"
-  integrity sha512-rxA0y5cW1AmdLAd/dxW2XmqkYhx9/v1sO2avSx8lIiTSH3Js2B0Cv0o4BfpkWtDa2nqf43pOvOVdgwVbxRkrPg==
+graphene-pk11@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/graphene-pk11/-/graphene-pk11-2.3.6.tgz#d6638798c852f97c610c79320f0d33813abdb1de"
+  integrity sha512-ol9Pf7XDv5UTjh1DPqtmQVZQqUheiXBzQVXQWRCLWq78+brKQB0Kum/s0NGEcsd/5NQQG8MFA2U/KNujEoC1fQ==
   dependencies:
-    pkcs11js "^2.1.1"
-    tslib "^2.6.2"
+    pkcs11js "^2.1.6"
+    tslib "^2.7.0"
 
 handlebars@^4.7.7:
   version "4.7.8"
@@ -5633,20 +5644,20 @@ node-releases@^2.0.14:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
   integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
 
-node-webcrypto-p11@^2.6.4:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/node-webcrypto-p11/-/node-webcrypto-p11-2.6.4.tgz#748efafae6cc40a7f31c8830a118d23d44752d16"
-  integrity sha512-vssFMc7MOciI2hEf6A+8OQIvi55Yz4tRBUPkhoBpOQsoVxChVjXyg9RAo6FN1ix+veYXDFCmXFy8Wn6wrA9VDQ==
+node-webcrypto-p11@^2.6.5:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/node-webcrypto-p11/-/node-webcrypto-p11-2.6.5.tgz#5cd8f96b0fa6b5ed31ed697ddf03f3a4c6da5036"
+  integrity sha512-0YyINuiaqVLt96uCWolYrJMBXTh3/QFtLPoOHGvJ8QJkbwecwU/gQZGx6wswun9EdLkAB9M0WFBhDb38Bqschw==
   dependencies:
-    "@peculiar/asn1-schema" "^2.3.8"
-    "@peculiar/asn1-x509" "^2.3.8"
+    "@peculiar/asn1-schema" "^2.3.13"
+    "@peculiar/asn1-x509" "^2.3.13"
     "@peculiar/json-schema" "^1.1.12"
-    "@peculiar/x509" "^1.9.6"
-    graphene-pk11 "^2.3.4"
-    pkcs11js "^2.0.1"
+    "@peculiar/x509" "^1.12.1"
+    graphene-pk11 "^2.3.6"
+    pkcs11js "^2.1.6"
     pvtsutils "^1.3.5"
-    tslib "^2.6.2"
-    webcrypto-core "^1.7.8"
+    tslib "^2.7.0"
+    webcrypto-core "^1.8.0"
 
 nopt@^6.0.0:
   version "6.0.0"
@@ -6367,10 +6378,10 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==
 
-pkcs11js@^2.0.1, pkcs11js@^2.1.1, pkcs11js@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/pkcs11js/-/pkcs11js-2.1.4.tgz#1a9ff218c37c53cc0d06065e4e81df7308b7b5ff"
-  integrity sha512-whhfbpM2YCot9IScGu3Tdq9HQAbs8vUqK2TTaYVok4VFLI21gu5u238T6CeGxGUXG81ukpab864JljaoMSt+XA==
+pkcs11js@2.1.6, pkcs11js@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/pkcs11js/-/pkcs11js-2.1.6.tgz#1d4847d6925b6f4aa37db71afa5d5241fac546cf"
+  integrity sha512-+t5jxzB749q8GaEd1yNx3l98xYuaVK6WW/Vjg1Mk1Iy5bMu/A5W4O/9wZGrpOknWF6lFQSb12FXX+eSNxdriwA==
 
 pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
@@ -7588,10 +7599,15 @@ tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.6.1, tslib@^2.6.2, tslib@^2.6.3:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.6.1, tslib@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
+
+tslib@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
+  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
 tslint@^6.1.3:
   version "6.1.3"
@@ -7612,7 +7628,7 @@ tslint@^6.1.3:
     tslib "^1.13.0"
     tsutils "^2.29.0"
 
-tsprotobuf@^1.0.15, tsprotobuf@^1.0.18, tsprotobuf@^1.0.19:
+tsprotobuf@^1.0.15, tsprotobuf@^1.0.19:
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/tsprotobuf/-/tsprotobuf-1.0.19.tgz#9d03b83f213e3e2e01468e0a9d9273ec94d7892e"
   integrity sha512-t3tkm2y8Nkq/cOfMYRFXhOHA+g/5W9wrzepVERxcnK0DTT/6rTJiR3bALq8aEtLARzPL3zN5xR9pWu0vrLy6bA==
@@ -7915,7 +7931,7 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-webcrypto-core@^1.0.17, webcrypto-core@^1.7.8, webcrypto-core@^1.8.0:
+webcrypto-core@^1.0.17, webcrypto-core@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.8.0.tgz#aaea17f3dd9c77c304e3c494eb27ca07cc72ca37"
   integrity sha512-kR1UQNH8MD42CYuLzvibfakG5Ew5seG85dMMoAM/1LqvckxaF6pUiidLuraIu4V+YCIFabYecUZAW0TuxAoaqw==


### PR DESCRIPTION
This pull request includes updates to the project's dependencies and significant improvements to the handling of the PCSC service. The dependencies have been updated to newer versions, including `pkcs11js`, and `node-webcrypto-p11`. Additionally, the logic for deleting the provider when deleting the token from the device has been changed. The PCSC watcher has been improved to handle the PCSC service being stopped, and information about managing the PCSC service on Windows has been added to the developer's guide.

## Changes

### Chore
- **chore:** Add information about PCSC service testing
- **chore:** Use `crypto.webcrypto` instead of global
- **chore(deps):** Update dependencies

### Fixes
- **fix:** Improve PCSC watcher to handle the PCSC service being stopped
  - This fix ensures that the PCSC watcher can handle the PCSC service being stopped without causing errors. It makes the application more robust by detecting the service status and adjusting its operations accordingly.

- **fix:** Change the logic of deleting the provider when deleting the token from the device
  - This fix updates the logic for deleting the provider when a token is removed from the device. The new logic ensures that all associated data and references are properly cleaned up, preventing potential issues with future operations.

- **fix:** Make `Map` iterable
  - This fix ensures that the `Map` object is iterable, allowing for easier and more efficient iteration over its entries.