### PR TITLE
ci: trust Coveralls Homebrew tap on macOS runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
         env:
           SOFT_HSM_LIBRARY: /opt/homebrew/Cellar/softhsm/2.7.0/lib/softhsm/libsofthsm2.so
 
+      - name: Trust Coveralls Homebrew tap
+        run: brew trust coverallsapp/coveralls
+
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:


### PR DESCRIPTION
## Summary
- Trust the `coverallsapp/coveralls` Homebrew tap before the Coveralls action so coverage upload works on `macos-latest` under Homebrew 6 tap-trust rules
- Fixes CI failures where tests pass but Coveralls exits with “Refusing to load formula … from untrusted tap”